### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Vocabularity
+
+A .NET 7.0 solution containing three minimal ASP.NET Core web apps, each currently exposing a single `GET /` endpoint that returns `Hello World!`:
+
+- `Vocabularity.API` — API service (in the solution `Vocabularity.sln`).
+- `Vocabularity.IdentityServer` — IdentityServer4-based auth service (in the solution).
+- `Vocabularity` — standalone web app project (NOT referenced by `Vocabularity.sln`; build it directly from its own folder).
+
+## Cursor Cloud specific instructions
+
+- The SDK is **.NET 7.0** (`net7.0`), installed at `/usr/share/dotnet` with a `dotnet` symlink in `/usr/local/bin`. .NET 7 is not available via apt on this image; it is provided via the dotnet-install script during environment setup (the update script only refreshes NuGet packages with `dotnet restore`).
+- Build/lint check: `dotnet build` from the repo root builds the two solution projects. There is no separate linter and there are no automated tests in this repo. Build `Vocabularity` separately (`cd Vocabularity && dotnet build`) since it is not in the solution.
+- Run a service in dev mode, e.g. `cd Vocabularity.API && ASPNETCORE_ENVIRONMENT=Development dotnet run --launch-profile http`. Default HTTP dev ports (from `Properties/launchSettings.json`): `Vocabularity.API` → 5051, `Vocabularity.IdentityServer` → 5273, `Vocabularity` → 5235. Verify with `curl http://localhost:<port>/` (expect `Hello World!`).
+- The `https` launch profiles rely on the ASP.NET Core dev certificate; prefer the `http` profile in this headless environment to avoid TLS trust issues.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this .NET 7.0 solution so future cloud agents can build, run, and test the apps.

- Installs the **.NET 7.0 SDK** (not available via apt on the base image; installed via the official dotnet-install script during environment setup).
- Configures the startup **update script** to `dotnet restore Vocabularity.sln` (minimal dependency refresh).
- Adds `AGENTS.md` documenting the services, build/run commands, dev ports, and Cloud-specific caveats.

## Verification

All three projects build, and both solution services serve their `GET /` endpoint in dev mode:

- `Vocabularity.API` → `http://localhost:5051/` → `200 OK` `Hello World!`
- `Vocabularity.IdentityServer` → `http://localhost:5273/` → `200 OK` `Hello World!`

[dotnet_dev_servers.log](https://cursor.com/agents/bc-fd2fe4f3-4b9a-41c8-872c-197fadd1e8e7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdotnet_dev_servers.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd2fe4f3-4b9a-41c8-872c-197fadd1e8e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd2fe4f3-4b9a-41c8-872c-197fadd1e8e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

