### PR TITLE
Set up Cursor Cloud dev environment for Vocabularity API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this repo is
+`backend/Vocabularity.sln` is a .NET 8 (ASP.NET Core) vocabulary/dictionary REST API. The
+runnable product is `Vocabularity.API`; `Vocabularity.Core` plus the `Vocabularity.Service.*`
+projects are class libraries it consumes. The data layer uses EF Core with **SQL Server**
+(migrated from Azure Cosmos DB). The other top-level folders (`BlazorApp*`, `WebApplication*`,
+`Vocabularity.AuthProvider`, `Vocabularity.Azure*`, `Vocabularity.IdentityServer`, etc.) are
+stray VS template scaffolding and are **not** part of `Vocabularity.sln` — ignore them.
+
+### Standard commands (run from `backend/`)
+- Restore: `dotnet restore Vocabularity.sln` (the update script already does this on startup)
+- Build: `dotnet build Vocabularity.sln -c Debug`
+- Lint/format check: `dotnet format Vocabularity.sln --verify-no-changes` (note: the optional
+  `Vocabularity.AzureADB2C` project currently has a pre-existing whitespace finding)
+- Run the API: `dotnet run --project Vocabularity.API` → listens on `http://localhost:5273`
+- There are **no automated test projects** in the repo; "testing" means build + hitting the HTTP
+  endpoints (e.g. `POST /language`, `GET /languages`, `POST /user`, `GET /users`, `GET /`).
+
+### SQL Server is required at runtime (non-obvious)
+`Vocabularity.API/Program.cs` calls `db.Database.Migrate()` on startup, so the API **crashes on
+boot if SQL Server is unreachable**. The committed dev connection string
+(`appsettings.Development.json`) points at Windows-only `(localdb)\mssqllocaldb`, which does not
+exist on Linux. A SQL Server 2022 Docker container (`vocab-sql`, sa password `Your_password123`,
+port 1433) is provisioned in the VM snapshot. Start it and point the API at it:
+
+```bash
+# 1. Start the Docker daemon (not auto-started on a fresh session)
+sudo dockerd >/tmp/dockerd.log 2>&1 &   # or run in a tmux session
+# 2. Start the SQL Server container (persisted in the snapshot)
+sudo docker start vocab-sql
+# 3. Run the API with the connection string overridden to the container
+cd backend
+export ASPNETCORE_ENVIRONMENT=Development
+export ConnectionStrings__DefaultConnection="Server=localhost,1433;Database=Vocabularity;User Id=sa;Password=Your_password123;TrustServerCertificate=True;MultipleActiveResultSets=True"
+dotnet run --project Vocabularity.API
+```
+
+If the `vocab-sql` container does not exist (e.g. snapshot not restored), recreate it:
+```bash
+sudo docker run -d --name vocab-sql -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Your_password123" \
+  -e "MSSQL_PID=Developer" -p 1433:1433 mcr.microsoft.com/mssql/server:2022-latest
+```
+
+### Docker on this VM (non-obvious)
+Docker uses the `fuse-overlayfs` storage driver with the containerd snapshotter disabled
+(`/etc/docker/daemon.json`) and iptables-legacy, because the Firecracker kernel lacks full
+overlay2/nftables support. Always start `dockerd` with `sudo`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Vocabularity .NET 8 API and documents non-obvious startup steps for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering build/lint/run commands, the mandatory SQL Server dependency, and Docker-on-VM caveats.
- Configures the update script (`dotnet restore backend/Vocabularity.sln`) to refresh NuGet packages on VM startup.

## Environment setup performed (captured in VM snapshot)

- Installed .NET 8 SDK (`8.0.128`).
- Installed Docker (fuse-overlayfs storage driver, iptables-legacy, containerd-snapshotter disabled).
- Provisioned a SQL Server 2022 container (`vocab-sql`, port 1433) since the API requires a reachable SQL Server (it runs EF migrations on boot; the committed dev connection string targets Windows-only LocalDB).

## Verification

Restored and built `Vocabularity.sln` (0 warnings, 0 errors), ran the API in Development mode against the SQL Server container (EF migrations created the `Vocabularity` DB + tables), and exercised the endpoints end-to-end.

```
$ curl http://localhost:5273/                       -> Hello World!
$ curl -X POST http://localhost:5273/language ...   -> created (id, ttl)
$ curl http://localhost:5273/languages              -> [ {Spanish}, {French} ]
$ curl -X POST http://localhost:5273/user ...        -> created (id, ttl)
$ curl http://localhost:5273/users                  -> [ {alice} ]
```

Rows confirmed persisted in SQL Server via `sqlcmd` (Languages = 1, Users = 1 at time of check).

[vocabularity_api_e2e.log](https://cursor.com/agents/bc-5a69ff09-0086-4341-bc74-dc9d0ac3ffd9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvocabularity_api_e2e.log)

No application code was modified.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a69ff09-0086-4341-bc74-dc9d0ac3ffd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a69ff09-0086-4341-bc74-dc9d0ac3ffd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

